### PR TITLE
Detect the types of gamepads hijacked by Steam

### DIFF
--- a/UnitySteamInputAdapter/Assets/Samples/Sample.cs
+++ b/UnitySteamInputAdapter/Assets/Samples/Sample.cs
@@ -12,10 +12,12 @@ public class Sample : MonoBehaviour
     private void Awake()
     {
         SteamAPI.Init();
+        SteamInput.Init(false);
     }
 
     private void OnDestroy()
     {
+        SteamInput.Shutdown();
         SteamAPI.Shutdown();
     }
 

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
@@ -114,7 +114,8 @@ namespace UnitySteamInputAdapter
         [System.Serializable]
         private class Capabilities
         {
-            public int userIndex = -1;
+            public const int InvalidValue = -1;
+            public int userIndex = InvalidValue;
         }
 
         /// <summary>
@@ -143,7 +144,7 @@ namespace UnitySteamInputAdapter
                 return false;
             }
             var capabilitiesValue = JsonUtility.FromJson<Capabilities>(capabilities);
-            if (capabilitiesValue.userIndex >= 0)
+            if (capabilitiesValue.userIndex != Capabilities.InvalidValue)
             {
                 for (int i = 0; i < steamDeviceCount; i++)
                 {

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
@@ -1,4 +1,5 @@
 #if SUPPORT_INPUTSYSTEM && SUPPORT_STEAMWORKS && !DISABLESTEAMWORKS
+using System;
 using Steamworks;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -111,7 +112,7 @@ namespace UnitySteamInputAdapter
 
         private static readonly InputHandle_t[] InputHandleBuffer = new InputHandle_t[Constants.STEAM_INPUT_MAX_COUNT];
 
-        [System.Serializable]
+        [Serializable]
         private class Capabilities
         {
             public const int InvalidValue = -1;
@@ -143,8 +144,20 @@ namespace UnitySteamInputAdapter
                 result = ESteamInputType.k_ESteamInputType_Unknown;
                 return false;
             }
-            var capabilitiesValue = JsonUtility.FromJson<Capabilities>(capabilities);
-            if (capabilitiesValue.userIndex != Capabilities.InvalidValue)
+
+            Capabilities capabilitiesValue;
+            try
+            {
+                capabilitiesValue = JsonUtility.FromJson<Capabilities>(capabilities);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                result = ESteamInputType.k_ESteamInputType_Unknown;
+                return false;
+            }
+
+            if (capabilities != null && capabilitiesValue.userIndex != Capabilities.InvalidValue)
             {
                 for (int i = 0; i < steamDeviceCount; i++)
                 {

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
@@ -123,6 +123,11 @@ namespace UnitySteamInputAdapter
         /// If the user enables Steam Input, all gamepads will be overridden to XInput.
         /// This function retrieves the type of gamepad before it is overridden.
         /// </summary>
+        /// <remarks>
+        /// If multiple gamepads are connected, the type of gamepad returned by this function might be swapped.
+        /// Only Steam can improve this, and there is nothing that Unity or we can do about it.
+        /// Users can resolve this issue by disabling Steam Input. Alternatively, restarting the game or unplugging and replugging all the gamepads may solve the problem.
+        /// </remarks>
         public static bool TryGetHijackedSteamInputDevice(InputDevice inputDevice, out ESteamInputType result)
         {
             if (inputDevice is not XInputController)


### PR DESCRIPTION
fixed https://github.com/eviltwo/UnitySteamInputAdapter/issues/1

Search for hijacked gamepads using Steam:`GamepadIndex` and Unity:`InputDevice.description.capabilities["userIndex"]`.