### PR TITLE
Supported control components

### DIFF
--- a/UnitySteamInputAdapter/Assets/Samples/Sample.cs
+++ b/UnitySteamInputAdapter/Assets/Samples/Sample.cs
@@ -6,7 +6,11 @@ using UnitySteamInputAdapter.Utils;
 
 public class Sample : MonoBehaviour
 {
+    [SerializeField]
+    private string[] _controlPaths = null;
+
     private Rect _deviceRect = new Rect(10, 10, 400, 0);
+    private Rect _actionRect = new Rect(10, 200, 400, 0);
     private Rect _buttonRect = new Rect(400, 10, 400, 0);
 
     private void Awake()
@@ -36,8 +40,20 @@ public class Sample : MonoBehaviour
             GUI.DragWindow();
         }, "Connected devices");
 
+        // Show actions
+        _actionRect = GUILayout.Window(1, _actionRect, id =>
+        {
+            for (int i = 0; i < _controlPaths.Length; i++)
+            {
+                var path = _controlPaths[i];
+                var steamAction = SteamInputAdapter.GetSteamInputAction(Gamepad.current, path);
+                GUILayout.Label($"Unity:{path}\nSteam:{steamAction}");
+            }
+            GUI.DragWindow();
+        }, "Action");
+
         // Show input controls. Convert Unity InputControl to Steam InputActionOrigin.
-        _buttonRect = GUILayout.Window(1, _buttonRect, id =>
+        _buttonRect = GUILayout.Window(2, _buttonRect, id =>
         {
             var devices = InputSystem.devices;
             foreach (var device in devices)
@@ -47,7 +63,7 @@ public class Sample : MonoBehaviour
                     foreach (var control in gamepad.allControls)
                     {
                         var steamAction = SteamInputAdapter.GetSteamInputAction(control);
-                        GUILayout.Label($"{InputSystemUtility.GetInputControlLocalPath(control)}({control.displayName}):\n{steamAction}");
+                        GUILayout.Label($"{InputSystemUtility.RemoveRootFromPath(control.path)}({control.displayName}):\n{steamAction}");
                     }
                 }
             }

--- a/UnitySteamInputAdapter/Assets/Samples/SampleScene.unity
+++ b/UnitySteamInputAdapter/Assets/Samples/SampleScene.unity
@@ -152,6 +152,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4d311a5b4ba976f4e9622b0a7c27e08c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _controlPaths:
+  - '*/buttonSouth'
+  - '*/{Submit}'
+  - '*/{Cancel}'
+  - '*/<Button>'
 --- !u!4 &1326685420
 Transform:
   m_ObjectHideFlags: 0
@@ -296,8 +301,8 @@ Camera:
   m_GameObject: {fileID: 2007798270}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.1254902, g: 0.1254902, b: 0.1254902, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/CHANGELOG.md
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.1] - 2024-07-13
+### Added
+- Added processing to convert indirect paths to direct paths.
+## Changed
+- Renamed `GetInputControlLocalPath()` to `RemoveRootFromPath()`. Internal processing was also changed.
+
 ## [1.0.0] - 2024-07-13
 ### Fixed
 - Fixed to recognize gamepads when the user has Steam Input enabled.

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/CHANGELOG.md
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [1.0.1] - 2024-07-13
 ### Added
 - Added processing to convert indirect paths to direct paths.
-## Changed
+  - Example: "XInputController/{Submit}" -> "XInputController/buttonSouth"
+### Changed
 - Renamed `GetInputControlLocalPath()` to `RemoveRootFromPath()`. Internal processing was also changed.
 
 ## [1.0.0] - 2024-07-13

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/SteamInputAdapter.cs
@@ -64,8 +64,33 @@ namespace UnitySteamInputAdapter
                 return EInputActionOrigin.k_EInputActionOrigin_None;
             }
 
+            if (string.IsNullOrEmpty(controlPath))
+            {
+                return EInputActionOrigin.k_EInputActionOrigin_None;
+            }
+
+            // Get path without device name.
+            // Example: "XInputController/buttonSouth" -> "buttonSouth"
+            var controlLocalPath = InputSystemUtility.RemoveRootFromPath(controlPath);
+
+            // Convert indirectory path to directory path.
+            // Example: "XInputController/{Submit}" -> "XInputController/buttonSouth"
+            if (InputSystemUtility.HasPathComponent(controlLocalPath))
+            {
+                var control = inputDevice.TryGetChildControl(controlPath);
+                if (control != null)
+                {
+                    controlPath = control.path;
+                    controlLocalPath = InputSystemUtility.RemoveRootFromPath(controlPath);
+                }
+            }
+
+            if (string.IsNullOrEmpty(controlLocalPath))
+            {
+                return EInputActionOrigin.k_EInputActionOrigin_None;
+            }
+
             // Get base input action (almost like XInput)
-            var controlLocalPath = InputSystemUtility.GetInputControlLocalPath(controlPath);
             var baseInputActionOrigin = GetBaseSteamInputAction(controlLocalPath);
             if (baseInputActionOrigin == EInputActionOrigin.k_EInputActionOrigin_None)
             {
@@ -186,7 +211,7 @@ namespace UnitySteamInputAdapter
         /// </summary>
         private static EInputActionOrigin GetBaseSteamInputAction(InputControl inputControl)
         {
-            var controlLocalPath = InputSystemUtility.GetInputControlLocalPath(inputControl);
+            var controlLocalPath = InputSystemUtility.RemoveRootFromPath(inputControl.path);
             return GetBaseSteamInputAction(controlLocalPath);
         }
 

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/Utils/InputSystemUtility.cs
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/Scripts/Utils/InputSystemUtility.cs
@@ -1,41 +1,36 @@
 #if SUPPORT_INPUTSYSTEM
-using System.Text;
 using UnityEngine.InputSystem;
 
 namespace UnitySteamInputAdapter.Utils
 {
     public static class InputSystemUtility
     {
-        private static StringBuilder _stringBuilder = new StringBuilder();
-
-        public static string GetInputControlLocalPath(InputControl inputControl)
-        {
-            return GetInputControlLocalPath(inputControl.path);
-        }
-
-        public static string GetInputControlLocalPath(string inputControlPath)
+        public static string RemoveRootFromPath(string inputControlPath)
         {
             if (string.IsNullOrEmpty(inputControlPath))
             {
-                return null;
+                return string.Empty;
             }
-            var pathComponents = InputControlPath.Parse(inputControlPath);
-            var enumerator = pathComponents.GetEnumerator();
-            if (!enumerator.MoveNext())
+            var startIndex = inputControlPath[0] == InputControlPath.Separator ? 1 : 0;
+            var separationIndex = inputControlPath.IndexOf(InputControlPath.Separator, startIndex);
+            if (separationIndex == -1)
             {
-                return null;
+                return inputControlPath;
             }
 
-            _stringBuilder.Clear();
-            while (enumerator.MoveNext())
+            if (separationIndex == inputControlPath.Length)
             {
-                if (_stringBuilder.Length > 0)
-                {
-                    _stringBuilder.Append(InputControlPath.Separator);
-                }
-                _stringBuilder.Append(enumerator.Current.name);
+                return string.Empty;
             }
-            return _stringBuilder.ToString();
+
+            return inputControlPath.Substring(separationIndex + 1);
+        }
+
+        public static bool HasPathComponent(string path)
+        {
+            return path.IndexOf('<') >= 0
+                || path.IndexOf('{') >= 0
+                || path.IndexOf('(') >= 0;
         }
     }
 }

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/package.json
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.eviltwo.unity-steam-input-adapter",
     "displayName": "Unity Steam Input Adapter",
-    "version": "1.0.0",             
+    "version": "1.0.1",             
     "unity": "2022.3",
     "description": "Change controller input from Unity(InputSystem) to Steam(InputAction)",
     "author": {

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest.meta
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f299f7bde6653a843b8e8a743dfb59db
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts.meta
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e69e8ae9390f7b4e959f5cffe4712bf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/InputSystemUtilityTest.cs
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/InputSystemUtilityTest.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnitySteamInputAdapter.Utils;
+
+namespace UnitySteamInputAdapterTest
+{
+    public class InputSystemUtilityTest : MonoBehaviour
+    {
+        [TestCase("/XInputController/buttonSouth", "buttonSouth")]
+        [TestCase("/XInputController/dpad/right", "dpad/right")]
+        [TestCase("/XInputController/<Button>", "<Button>")]
+        [TestCase("/XInputController/{Submit}", "{Submit}")]
+        [TestCase("/XInputController/#(a)", "#(a)")]
+        [TestCase("/<Gamepad>/buttonSouth", "buttonSouth")]
+        [TestCase("/<Gamepad>/buttonSouth", "buttonSouth")]
+        [TestCase("XInputController/buttonSouth", "buttonSouth")]
+        [TestCase("*/buttonSouth", "buttonSouth")]
+        public void RemoveRootFromPath(string input, string expected)
+        {
+            var result = InputSystemUtility.RemoveRootFromPath(input);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("/XInputController/buttonSouth", false)]
+        [TestCase("/XInputController/dpad/right", false)]
+        [TestCase("/XInputController/<Button>", true)]
+        [TestCase("/XInputController/{Submit}", true)]
+        [TestCase("/XInputController/#(a)", true)]
+        public void HasPathComponent(string input, bool expected)
+        {
+            var result = InputSystemUtility.HasPathComponent(input);
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/InputSystemUtilityTest.cs.meta
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/InputSystemUtilityTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bb5227cdf0c74149aa6995557aa1d9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/UnitySteamInputAdapterTest.asmdef
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/UnitySteamInputAdapterTest.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "UnitySteamInputAdapterTest",
+    "rootNamespace": "",
+    "references": [
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:51a288164b64a274ca0e204a55cf0945"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/UnitySteamInputAdapterTest.asmdef.meta
+++ b/UnitySteamInputAdapter/Assets/UnitySteamInputAdapterTest/Scripts/UnitySteamInputAdapterTest.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bb8d4ce8cd24145449157e8c37ffada8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Added
- Added processing to convert indirect paths to direct paths.
  - Example: "XInputController/{Submit}" -> "XInputController/buttonSouth"
### Changed
- Renamed `GetInputControlLocalPath()` to `RemoveRootFromPath()`. Internal processing was also changed.